### PR TITLE
Remove adding getVRDisplays to navigator.

### DIFF
--- a/XX-monoscopic-rendering.html
+++ b/XX-monoscopic-rendering.html
@@ -40,8 +40,6 @@ found in the LICENSE file.
     <script src="js/third-party/wglu/wglu-stats.js"></script>
     <script src="js/third-party/wglu/wglu-texture.js"></script>
 
-    <script src="js/third-party/webvr-polyfill.js"></script>
-
     <script src="js/vr-cube-sea.js"></script>
     <script src="js/vr-samples-util.js"></script>
   </head>


### PR DESCRIPTION
webvr-polyfill.js adds getVRDisplays to navigator. So "if (navigator.getVRDisplay) {" at 180 line does not check availability WebVR API.

For example, Chrome 48 does not support WebVR API, but  says "WebVR supported, but no VRDisplays found."