### PR TITLE
Change precision of display of floats

### DIFF
--- a/00-hello-webvr.html
+++ b/00-hello-webvr.html
@@ -89,9 +89,11 @@ found in the LICENSE file.
                   value += ",";
                 if (obj[key][idx] >= 0)
                   value += " ";
-                value += obj[key][idx].toFixed(2);
+                value += obj[key][idx].toFixed(3);
               }
               li.innerHTML = "<b>" + key + ":</b> <span class='float-array'>[" + value + " ]</span>";
+            } else if (typeof obj[key] === "number" && obj[key] !== (obj[key]|0)) {
+              li.innerHTML = "<b>" + key + ":</b> " + obj[key].toFixed(3);
             } else if (typeof obj[key] === "object") {
               li.innerHTML = "<b>" + key + ":</b>";
               li.appendChild(buildMemberList(obj[key]));


### PR DESCRIPTION
For:
-offset/IPD: often given in mm and HW adjustable near to
-FOV: 3 decimal degrees display sufficient
-pose: tracking often referenced down to mm
==
Minor but I find this easier in a few ways when debugging, modifying IPD, etc.