### PR TITLE
add redirects for all other pages (<page>.html -> https://webvr.info/samples/<page>.html)

### DIFF
--- a/00-hello-webvr.html
+++ b/00-hello-webvr.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/00-hello-webvr.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/01-vr-input.html
+++ b/01-vr-input.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/01-vr-input.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"> <!-- No pinch zoom on mobile -->
     <meta name="mobile-web-app-capable" content="yes"> <!-- Launch fullscreen when added to home screen -->
     <meta name="apple-mobile-web-app-capable" content="yes"> <!-- Fullscreen Landscape on iOS -->

--- a/02-stereo-rendering.html
+++ b/02-stereo-rendering.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/02-stereo-rendering.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes"> <!-- Fullscreen Landscape on iOS -->
 

--- a/03-vr-presentation.html
+++ b/03-vr-presentation.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/03-vr-presentation.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/04-simple-mirroring.html
+++ b/04-simple-mirroring.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/04-simple-mirroring.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/04b-simple-mirroring-2.html
+++ b/04b-simple-mirroring-2.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/04b-simple-mirroring-2.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/05-room-scale.html
+++ b/05-room-scale.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/05-room-scale.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/06-vr-audio.html
+++ b/06-vr-audio.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/06-vr-audio.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/07-advanced-mirroring.html
+++ b/07-advanced-mirroring.html
@@ -7,6 +7,11 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/07-advanced-mirroring.html">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/08-dynamic-resolution.html
+++ b/08-dynamic-resolution.html
@@ -7,6 +7,10 @@ found in the LICENSE file.
 <html>
   <head>
     <meta charset="utf-8">
+    <script>
+      // This example has moved!
+      window.location.href = 'https://webvr.info/samples/' + window.location.href.substring(window.location.href.lastIndexOf('/') + 1);
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ These examples are intended to demonstrate basic use of the WebVR API without fr
 The code makes use of some simple WebGL utilities (js/wglu) and the glMatrix library to reduce
 complexity of the WebGL code, but neither are necessary for using WebVR.
 
-You can run these samples live at https://toji.github.io/webvr-samples/
+You can run these samples live at **https://webvr.io/webvr-samples/**
 
 # Experience Prerequisites
 These samples use WebGL and matrix math to demonstrate the WebVR API. While most of it is hidden
@@ -13,8 +13,8 @@ behind libraries and utility functions for brevity, it's assumed that you have a
 conceptual knowledge of both.
 
 # Further Reading
- - [WebVR Spec](https://mozvr.github.io/webvr-spec/)
- - [How to Get WebVR](http://webvr.info/)
+ - [WebVR Spec](https://w3c.github.io/webvr/)
+ - [How to Get WebVR](https://webvr.info/)
 
 # Attributions
 WebVR image used with the permission of [Jaume Sanchez](https://www.clicktorelease.com/).

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <title>Redirecting… | WebVR Samples have moved!</title>
     <meta charset="utf-8">
     <script>
-      window.location.href = 'https://webvr.info/samples'
+      window.location.href = 'https://webvr.info/samples/';
     </script>
-    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples">
+    <meta http-equiv="refresh" content="1; url=https://webvr.info/samples/">
   </head>
   <body>
   </body>


### PR DESCRIPTION
when merged, this will handle all legacy URLs, with and without query-string parameters:

* https://toji.github.io/webvr-samples/00-hello-webvr.html
* https://toji.github.io/webvr-samples/08-dynamic-resolution.html?polyfill=1

It's worth noting that these are client-side redirects (server-side would be best), but these are fine for now.
